### PR TITLE
fix anatomical findings csv download

### DIFF
--- a/studies/processors/brain_images.py
+++ b/studies/processors/brain_images.py
@@ -40,7 +40,7 @@ class BrainImagesDataProcessor(BaseProcessor):
     def process(self):
         queryset = self.get_queryset()
         if self.is_csv:
-            return queryset.values_list("id", flat=True)
+            return queryset.values_list("experiment_id", flat=True)
 
         # turn queryset to pandas df
 


### PR DESCRIPTION
## Summary
- The `BrainImagesDataProcessor.process()` is_csv branch returned `FindingTag` ids, but the graph view feeds the returned ids into `Experiment.objects.related().filter(id__in=...)`. As a result the anatomical findings CSV download produced empty/incorrect results.
- Fixed by returning `experiment_id` from the queryset instead.

## Test plan
- [ ] Open `/anatomical-findings`, set filters, click Download — verify the CSV contains the experiments that contributed to the displayed brain image.
- [ ] Verify the non-CSV (JSON) brain image response is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)