### PR TITLE
test: smoke every admin changelist

### DIFF
--- a/studies/tests/test_admin_smoke.py
+++ b/studies/tests/test_admin_smoke.py
@@ -1,0 +1,40 @@
+from django.contrib import admin
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+User = get_user_model()
+
+APP_LABEL = "studies"
+
+
+class AdminChangelistSmokeTest(TestCase):
+    """
+    Smokes every admin-registered model's changelist in the studies app.
+    Guards against breakage from Django / library upgrades without depending
+    on per-model fixtures — empty changelists still exercise list_display,
+    list_filter, search_fields, and queryset overrides.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username="admin_smoke_studies", password="x", email="admin_smoke_studies@example.com"
+        )
+
+    def setUp(self):
+        self.client.force_login(self.admin_user)
+
+    def test_all_registered_changelists_load(self):
+        models = [m for m in admin.site._registry if m._meta.app_label == APP_LABEL]
+        self.assertGreater(len(models), 0, f"No admin models registered for app '{APP_LABEL}'")
+
+        for model in models:
+            with self.subTest(model=model.__name__):
+                url = reverse(f"admin:{APP_LABEL}_{model._meta.model_name}_changelist")
+                response = self.client.get(url)
+                self.assertEqual(
+                    response.status_code,
+                    200,
+                    f"{model.__name__} changelist returned {response.status_code}",
+                )

--- a/uncontrast_studies/tests/test_admin_smoke.py
+++ b/uncontrast_studies/tests/test_admin_smoke.py
@@ -1,0 +1,40 @@
+from django.contrib import admin
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+User = get_user_model()
+
+APP_LABEL = "uncontrast_studies"
+
+
+class AdminChangelistSmokeTest(TestCase):
+    """
+    Smokes every admin-registered model's changelist in the uncontrast_studies app.
+    Guards against breakage from Django / library upgrades without depending
+    on per-model fixtures — empty changelists still exercise list_display,
+    list_filter, search_fields, and queryset overrides.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username="admin_smoke_uncontrast", password="x", email="admin_smoke_uncontrast@example.com"
+        )
+
+    def setUp(self):
+        self.client.force_login(self.admin_user)
+
+    def test_all_registered_changelists_load(self):
+        models = [m for m in admin.site._registry if m._meta.app_label == APP_LABEL]
+        self.assertGreater(len(models), 0, f"No admin models registered for app '{APP_LABEL}'")
+
+        for model in models:
+            with self.subTest(model=model.__name__):
+                url = reverse(f"admin:{APP_LABEL}_{model._meta.model_name}_changelist")
+                response = self.client.get(url)
+                self.assertEqual(
+                    response.status_code,
+                    200,
+                    f"{model.__name__} changelist returned {response.status_code}",
+                )


### PR DESCRIPTION
## Summary
- Adds a parametrized smoke test in `studies/tests/test_admin_smoke.py` and `uncontrast_studies/tests/test_admin_smoke.py` that iterates `admin.site._registry` filtered by app label and GETs every registered model's changelist URL.
- Closes the existing coverage gap (previously only ~9 of 44 registered admin models had a changelist smoke test) and stays in sync automatically as models are added.
- Empty changelists still exercise `list_display`, `list_filter`, `search_fields`, and `get_queryset` overrides — useful as a safety net for Django / `import-export` / `simple-history` / `two-factor` upgrades.

## Test plan
- [x] `DJANGO_CONFIGURATION=Testing poetry run python manage.py test studies.tests.test_admin_smoke uncontrast_studies.tests.test_admin_smoke` — both pass, covering 24 + 20 models.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)